### PR TITLE
Enable automatic GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - run: flutter pub get
+      - run: flutter build web --release --base-href /flutter_boids/
+      - run: |
+          rm -rf docs
+          mv build/web docs
+      - name: Commit and push changes
+        run: |
+          git config user.name 'GitHub Actions'
+          git config user.email 'actions@github.com'
+          git add docs
+          git commit -m 'chore: deploy web output' || echo 'No changes to commit'
+          git push


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Flutter web site
- push the generated `build/web` contents to the `docs` directory so GitHub Pages stays updated

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684221726a68832fab7c514e4da3e84d