### PR TITLE
Fix angle wrapping issues in boid simulation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -495,6 +495,7 @@ class Boid {
   double _normaliseDirection(double angle) {
     angle = angle % (2 * pi);
     if (angle > pi) angle -= 2 * pi;
+    if (angle <= -pi) angle += 2 * pi;
     return angle;
   }
 
@@ -506,10 +507,8 @@ class Boid {
   bool _isAwareOfThisPoint(
       Point<double> point, double awarenessDistance, double awarenessArc) {
     if (_distanceToOtherPoint(point) <= awarenessDistance) {
-      final angleToOther = _directionToOtherPoint(point);
-      final minAngle = _direction - (awarenessArc / 2);
-      final maxAngle = _direction + (awarenessArc / 2);
-      return angleToOther >= minAngle && angleToOther <= maxAngle;
+      final relativeDir = _relativeDirectionToOtherPoint(point).abs();
+      return relativeDir <= awarenessArc / 2;
     }
     return false;
   }


### PR DESCRIPTION
## Summary
- fix angle normalisation when direction is below `-pi`
- simplify and correct boid awareness check

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684221490da8832fadb9637f9c9d9b82